### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1
+        id: deploy

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ A modern, minimalist web-based word counter that supports English and Traditiona
 ## Usage
 
 Open `index.html` in a web browser. Enter or paste text into the textarea. Select the desired language, and view the statistics below the text box. Use the **Clear** button to reset the input. Use **Export Text** to download a `.txt` file or **Export PDF** for a `.pdf` file containing the stats.
+
+## Deploying to GitHub Pages
+
+1. Create a repository on GitHub and push this project to it.
+2. Copy the workflow in `.github/workflows/deploy.yml` included in this repo. GitHub Actions will build and publish the site whenever changes are pushed to `main`.
+3. In the repository's **Settings > Pages**, choose **GitHub Actions** as the source.
+4. After the workflow finishes, your site will be available at `https://<username>.github.io/<repository>`.
+
+Alternatively, you can enable GitHub Pages directly from the settings without using Actions by selecting the `main` branch as the source and saving.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that publishes the site to GitHub Pages
- update README with instructions on deploying the site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f9f5f4ae48325aa590025bf45a526