### PR TITLE
Improve stats layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,16 +122,16 @@ function updateStats() {
     const speaking = estimateSpeakingTime(lang === 'zh' ? characters : words, lang);
 
     statsDiv.innerHTML = `
-        <ul>
-            <li>${s.words}: ${words}</li>
-            <li>${s.characters}: ${characters}</li>
-            <li>${s.paragraphs}: ${paragraphs}</li>
-            <li>${s.sentences}: ${sentences}</li>
-            <li>${s.unique}: ${unique}</li>
-            <li>${s.noSpaces}: ${noSpaces}</li>
-            <li>${s.reading}: ${reading}</li>
-            <li>${s.speaking}: ${speaking}</li>
-        </ul>
+        <div class="stat-grid">
+            <div class="stat-item"><span class="stat-value">${words}</span><span class="stat-label">${s.words}</span></div>
+            <div class="stat-item"><span class="stat-value">${characters}</span><span class="stat-label">${s.characters}</span></div>
+            <div class="stat-item"><span class="stat-value">${paragraphs}</span><span class="stat-label">${s.paragraphs}</span></div>
+            <div class="stat-item"><span class="stat-value">${sentences}</span><span class="stat-label">${s.sentences}</span></div>
+            <div class="stat-item"><span class="stat-value">${unique}</span><span class="stat-label">${s.unique}</span></div>
+            <div class="stat-item"><span class="stat-value">${noSpaces}</span><span class="stat-label">${s.noSpaces}</span></div>
+            <div class="stat-item"><span class="stat-value">${reading}</span><span class="stat-label">${s.reading}</span></div>
+            <div class="stat-item"><span class="stat-value">${speaking}</span><span class="stat-label">${s.speaking}</span></div>
+        </div>
     `;
 }
 

--- a/style.css
+++ b/style.css
@@ -79,6 +79,31 @@ textarea {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+}
+
+.stat-item {
+    background: var(--bg-color);
+    padding: 10px;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.stat-value {
+    font-size: 1.2em;
+    font-weight: 600;
+    display: block;
+}
+
+.stat-label {
+    margin-top: 4px;
+    font-size: 0.85em;
+}
+
 .stats ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- modernize statistics display by showing items in a responsive grid
- add new CSS classes for stat grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa464828c8325ae11c99e109ec1bc